### PR TITLE
offset_as_seconds: handle integer-only offsets (Etc/GMT[+-]nn)

### DIFF
--- a/lib/DateTime/TimeZone.pm
+++ b/lib/DateTime/TimeZone.pm
@@ -456,9 +456,6 @@ sub offset_as_seconds {
     elsif ( $offset =~ /^([\+\-])?(\d\d)(\d\d)(\d\d)?$/ ) {
         ( $sign, $hours, $minutes, $seconds ) = ( $1, $2, $3, $4 );
     }
-    elsif ( $offset =~ /^([\+\-])?(\d\d?)$/ ) {
-        ( $sign, $hours, $minutes, $seconds ) = ( $1, $2, 0, 0);
-    }
     else {
         return undef;
     }

--- a/lib/DateTime/TimeZone.pm
+++ b/lib/DateTime/TimeZone.pm
@@ -456,6 +456,9 @@ sub offset_as_seconds {
     elsif ( $offset =~ /^([\+\-])?(\d\d)(\d\d)(\d\d)?$/ ) {
         ( $sign, $hours, $minutes, $seconds ) = ( $1, $2, $3, $4 );
     }
+    elsif ( $offset =~ /^([\+\-])?(\d\d?)$/ ) {
+        ( $sign, $hours, $minutes, $seconds ) = ( $1, $2, 0, 0);
+    }
     else {
         return undef;
     }

--- a/lib/DateTime/TimeZone/OlsonDB/Observance.pm
+++ b/lib/DateTime/TimeZone/OlsonDB/Observance.pm
@@ -26,7 +26,9 @@ sub new {
     );
 
     my $offset_from_utc
-        = DateTime::TimeZone::offset_as_seconds( $p{gmtoff} );
+        = $p{gmtoff} =~ m/^[+-]?\d?\d$/  # only hours? need to handle specially
+        ? 3600 * $p{gmtoff}
+        : DateTime::TimeZone::offset_as_seconds( $p{gmtoff} );
 
     my $offset_from_std
         = DateTime::TimeZone::offset_as_seconds( $p{offset_from_std} );


### PR DESCRIPTION
This fixes the bug with parsing integer only hour gmtoff values (aka the Etc/GMT things) that I introduced in backing out the reversed logic... but with the complexity in the same place as the other parsers.